### PR TITLE
Add scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,13 +15,13 @@
     "src"
   ],
   "devDependencies": {
-    "electron-compile": "^0.7.0",
+    "electron-compile": "^0.7.4",
     "electron-jasmine": "^0.1.8",
     "electron-packager": "^5.0.1",
-    "electron-prebuilt": "^0.30.1",
+    "electron-prebuilt": "^0.30.2",
     "electron-rebuild": "^0.2.5"
   },
   "dependencies": {
-    "yargs": "^3.15.0"
+    "yargs": "^3.16.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "electron-compile": "^0.7.0",
     "electron-jasmine": "^0.1.8",
     "electron-prebuilt": "^0.30.1",
-    "husk-cli": "^0.2.0"
+    "electron-rebuild": "^0.2.5"
   },
   "dependencies": {
     "yargs": "^3.15.0"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "electron-compile": "^0.7.0",
     "electron-jasmine": "^0.1.8",
+    "electron-packager": "^5.0.1",
     "electron-prebuilt": "^0.30.1",
     "electron-rebuild": "^0.2.5"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/benogle/electron-sample.git"
   },
   "scripts": {
-    "test": "node_modules/.bin/electron . --test"
+    "test": "script/test"
   },
   "compileCacheDir": "./compile-cache",
   "compileDirs": [

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+MODULE_PATH="./node_modules"
+REBUILD_PATH="$MODULE_PATH/.bin/electron-rebuild"
+PREBUILT_PATH="$MODULE_PATH/electron-prebuilt"
+PACKAGE_JSON_PATH="$PREBUILT_PATH/package.json"
+
+function json_value {
+  # From https://gist.github.com/cjus/1047794
+  cat $1 | sed 's/\\\\\//\//g' | sed 's/[{}]//g' | awk -v k="text" '{n=split($0,a,","); for (i=1; i<=n; i++) print a[i]}' | sed 's/\"\:\"/\|/g' | sed 's/[\,]/ /g' | sed 's/\"//g' | grep -w $2 | tr ": " " "
+}
+
+ELECTRON_VERSION=($( json_value $PACKAGE_JSON_PATH "version" ))
+ELECTRON_VERSION=${ELECTRON_VERSION[1]}
+
+echo "Electron Version: $ELECTRON_VERSION"
+
+npm install
+$REBUILD_PATH --version "$ELECTRON_VERSION" --electron-prebuilt-dir "$PREBUILT_PATH" --module-dir "$MODULE_PATH"

--- a/script/build
+++ b/script/build
@@ -11,7 +11,7 @@ PATH_TO_COMPILE="./src"
 COMPILE_CACHE_PATH="./compile-cache"
 BUILD_OUTPUT_PATH="./release"
 
-IGNORE_PATHS="$MODULE_PATH/electron-compile/node_modules/electron-compilers|$MODULE_PATH/\\.bin"
+IGNORE_PATHS="node_modules/electron-compile/node_modules/electron-compilers|node_modules/\\.bin|node_modules/electron-rebuild|node_modules/electron-jasmine|(/release$)|(/script$)|(/spec$)"
 
 function json_value {
   # From https://gist.github.com/cjus/1047794

--- a/script/build
+++ b/script/build
@@ -1,15 +1,12 @@
 #!/bin/bash
 
 MODULE_PATH="./node_modules"
-COMPILER_PATH="$MODULE_PATH/.bin/electron-compile"
 PACKAGER_PATH="$MODULE_PATH/.bin/electron-packager"
 PREBUILT_PATH="$MODULE_PATH/electron-prebuilt"
 PREBUILT_PACKAGE_JSON_PATH="$PREBUILT_PATH/package.json"
 PACKAGE_JSON_PATH="package.json"
-
-PATH_TO_COMPILE="./src"
-COMPILE_CACHE_PATH="./compile-cache"
 BUILD_OUTPUT_PATH="./release"
+COMPILE_COMMAND="./script/compile"
 
 IGNORE_PATHS="node_modules/electron-compile/node_modules/electron-compilers|node_modules/\\.bin|node_modules/electron-rebuild|node_modules/electron-jasmine|(/release$)|(/script$)|(/spec$)"
 
@@ -24,6 +21,7 @@ ELECTRON_VERSION=${ELECTRON_VERSION[1]}
 APP_NAME=($( json_value $PACKAGE_JSON_PATH "appName" ))
 APP_NAME=${APP_NAME[1]}
 
+$COMPILE_COMMAND
+
 echo "Building $APP_NAME"
-$COMPILER_PATH --target "$COMPILE_CACHE_PATH" "$PATH_TO_COMPILE"
 $PACKAGER_PATH ./ $APP_NAME --overwrite --platform darwin --arch x64 --version "$ELECTRON_VERSION" --ignore "$IGNORE_PATHS" --out "$BUILD_OUTPUT_PATH" $@

--- a/script/build
+++ b/script/build
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+MODULE_PATH="./node_modules"
+COMPILER_PATH="$MODULE_PATH/.bin/electron-compile"
+PACKAGER_PATH="$MODULE_PATH/.bin/electron-packager"
+PREBUILT_PATH="$MODULE_PATH/electron-prebuilt"
+PREBUILT_PACKAGE_JSON_PATH="$PREBUILT_PATH/package.json"
+PACKAGE_JSON_PATH="package.json"
+
+PATH_TO_COMPILE="./src"
+COMPILE_CACHE_PATH="./compile-cache"
+BUILD_OUTPUT_PATH="./release"
+
+IGNORE_PATHS="$MODULE_PATH/electron-compile/node_modules/electron-compilers|$MODULE_PATH/\\.bin"
+
+function json_value {
+  # From https://gist.github.com/cjus/1047794
+  cat $1 | sed 's/\\\\\//\//g' | sed 's/[{}]//g' | awk -v k="text" '{n=split($0,a,","); for (i=1; i<=n; i++) print a[i]}' | sed 's/\"\:\"/\|/g' | sed 's/[\,]/ /g' | sed 's/\"//g' | grep -w $2 | tr ": " " "
+}
+
+ELECTRON_VERSION=($( json_value $PREBUILT_PACKAGE_JSON_PATH "version" ))
+ELECTRON_VERSION=${ELECTRON_VERSION[1]}
+
+APP_NAME=($( json_value $PACKAGE_JSON_PATH "appName" ))
+APP_NAME=${APP_NAME[1]}
+
+echo "Building $APP_NAME"
+$COMPILER_PATH --target "$COMPILE_CACHE_PATH" "$PATH_TO_COMPILE"
+$PACKAGER_PATH ./ $APP_NAME --overwrite --platform darwin --arch x64 --version "$ELECTRON_VERSION" --ignore "$IGNORE_PATHS" --out "$BUILD_OUTPUT_PATH" $@

--- a/script/compile
+++ b/script/compile
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+MODULE_PATH="./node_modules"
+COMPILER_PATH="$MODULE_PATH/.bin/electron-compile"
+
+PATH_TO_COMPILE="./src"
+COMPILE_CACHE_PATH="./compile-cache"
+
+echo "Compiling..."
+$COMPILER_PATH --target "$COMPILE_CACHE_PATH" $PATH_TO_COMPILE

--- a/script/run
+++ b/script/run
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+MODULE_PATH="./node_modules"
+ELECTRON_PATH="$MODULE_PATH/.bin/electron"
+
+$ELECTRON_PATH . --environment development $@

--- a/script/test
+++ b/script/test
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+MODULE_PATH="./node_modules"
+ELECTRON_PATH="$MODULE_PATH/.bin/electron"
+
+$ELECTRON_PATH . --test $@


### PR DESCRIPTION
This adds a few scripts

```bash
script/bootstrap
script/run
script/test
script/build
```

The build script is the sketchiest. It assumes a darwin x64 build. You can pass more `--platform` options to the build script as well. Would be nice if this were smarter and figured out the current system/arch and built that by default. Buuut I dont want to make it complicated at this time.

cc @jlord @kevinsawicki 