### PR TITLE
Update build to be multiplatform

### DIFF
--- a/script/build
+++ b/script/build
@@ -21,7 +21,10 @@ ELECTRON_VERSION=${ELECTRON_VERSION[1]}
 APP_NAME=($( json_value $PACKAGE_JSON_PATH "appName" ))
 APP_NAME=${APP_NAME[1]}
 
+PLATFORM=${PLATFORM:-$( node -e "console.log(process.platform)" )}
+ARCH=${ARCH:-$( node -e "console.log(process.arch)" )}
+
 $COMPILE_COMMAND
 
 echo "Building $APP_NAME"
-$PACKAGER_PATH ./ $APP_NAME --overwrite --platform darwin --arch x64 --version "$ELECTRON_VERSION" --ignore "$IGNORE_PATHS" --out "$BUILD_OUTPUT_PATH" $@
+$PACKAGER_PATH ./ $APP_NAME --overwrite --platform $PLATFORM --arch $ARCH --version "$ELECTRON_VERSION" --ignore "$IGNORE_PATHS" --out "$BUILD_OUTPUT_PATH" $@


### PR DESCRIPTION
Hi Guys,

I'm trying electron with a toy app called [cr](http://github.com/dukex/cr) and using eletron-sample. I use linux to work, so this pull request enable the multiplatform build.

I love the idea to use shell script instead of gulp, grunt, etc. The build now get the platform and arch by default from the current system(using node), but you can set PLATFORM or ARCH env to build to others platform and arch.

Examples, given my platform is darwin and arch is x86

``` sh
$ ./scripts/build
Compiling...
Building CR
Packaging app for platform darwin x86 using electron v0.30.2
Wrote new app to release/CR-darwin-x64
```

Build I can crosscompile to linux using PLATFORM env

``` sh
$ PLATFORM=linux ./scripts/build
Compiling...
Building CR
Packaging app for platform linux x86 using electron v0.30.2
Wrote new app to release/CR-linux-x64
```

Or change the arch
``` sh
$ PLATFORM=linux ARCH=ia32 ./scripts/build
Compiling...
Building CR
Packaging app for platform linux ia32 using electron v0.30.2
Wrote new app to release/CR-linux-ia32
```

Please let me know if I missing something.





